### PR TITLE
Fix devShells in the example flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ mkShell {
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
     zephyr = zephyr-nix.packages.x86_64-linux;
   in {
-    devShell.x86_64-linux.default = pkgs.mkShell {
+    devShells.x86_64-linux.default = pkgs.mkShell {
       # Use the same mkShell as documented above
     };
   };


### PR DESCRIPTION
When trying to use the example flake.nix, the following error is given: "error: flake output attribute 'devShell.x86_64-linux' is not a derivation or path" This is due to a missing 's' in 'devShells.x86_64-linux'