### PR TITLE
python: allow passing extra arguments for the derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,4 @@
-{ callPackage
-, zephyr-src
+{ zephyr-src
 , pyproject-nix
 , lib
 , fetchurl

--- a/python.nix
+++ b/python.nix
@@ -4,6 +4,7 @@
 , clang-tools
 , gitlint
 , lib
+, ...
 }:
 
 let


### PR DESCRIPTION
When using a `shell.nix` with something as:

```
| pkgs.mkShell {
|   packages = with pkgs; [
|     ...
|     (zephyr.pythonEnv.override (old: {
|       extraLibs = old.extraLibs ++ [
|         zephyr.pythonEnv.pythonPackages.natsort
|       ];
|     }))
|     ...
|   ];
| };

```
The evaluation fails with:

```
| error: function 'anonymous lambda' called with unexpected argument 'extraLibs'
|
| at /nix/store/1a91ssj05ax8maksrii3k6aav873axcq-source/python.nix:1:1:
|
|      1| { python3
|       | ^
|      2| , zephyr-src

```
This commit fixes it allowing the lambda to receive extra arguments.
