### PR TITLE
hosttools: skip the fixup phase

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -141,6 +141,7 @@ in {
         buildInputs = [ python3 ];
 
         dontBuild = true;
+        dontFixup = true;
 
         sourceRoot = ".";
 


### PR DESCRIPTION
Avoid to apply the patchelf command to ELF executables and libraries to
remove unused directories from the RPATH.

Fixes:

% openocd
openocd: /nix/store/.../hosttools/.../lib/libc.so.6: version
`GLIBC_ABI_DT_RELR' not found (required by
/nix/store/.../...h9x-glibc-2.38-44/lib/libpthread.so.0)