### PR TITLE
python: allow passing extra arguments for the derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,4 @@
-{ callPackage
-, zephyr-src
+{ zephyr-src
 , pyproject-nix
 , lib
 , fetchurl

--- a/python.nix
+++ b/python.nix
@@ -4,6 +4,7 @@
 , clang-tools_17
 , gitlint
 , lib
+, extraPackages ? _ps: [ ]
 }:
 
 let
@@ -31,5 +32,5 @@ lib.warnIf
   "zephyr-pythonEnv: Found invalid Python constraints for: ${builtins.toJSON (lib.attrNames invalidConstraints)}"
   (python.withPackages (project.renderers.withPackages {
     inherit python;
-    extraPackages = ps: [ ps.west ];
+    extraPackages = ps: [ ps.west ] ++ extraPackages ps;
   }))


### PR DESCRIPTION
When using a `shell.nix` with something as:

```
,----
| pkgs.mkShell {
|   packages = with pkgs; [
|     ...
|     (zephyr.pythonEnv.override {
|       extraPackages = ps: [ ps.stringcase ];
|     }))
|     ...
|   ];
| };
`----
```
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>