### PR TITLE
Use Python 3.9

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 , pyproject-nix
 , lib
 , fetchurl
-, python38
+, python39
 , newScope
 , openocd
 , autoreconfHook
@@ -31,7 +31,7 @@ let
   };
 
   sdkArgs = {
-    python3 = python38;
+    python3 = python39;
   };
 
 in


### PR DESCRIPTION
Python 3.8 is not in the current nixpkgs, leading to the following error:
```
lib.customisation.callPackageWith: Function called without required argument "python38" at /nix/store/x9xjk43j6g21j613c0nq6i4pd209q1mk-source/default.nix:6, did you mean "python3", "python39" or "python"?
```

Using `python39` appears to fix it.