### PR TITLE
Fix getArch on aarch64

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,8 +20,8 @@ let
     else throw "Unsupported platform";
 
   getArch = stdenv:
-    if stdenv.isLinux then stdenv.hostPlatform.linuxArch
-    else if stdenv.isDarwin then stdenv.hostPlatform.darwinArch
+    if stdenv.isAarch64 then "aarch64"
+    else if stdenv.isx86_64 then "x86_64"
     else throw "Unsupported arch";
 
   baseURL = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${version}";


### PR DESCRIPTION
`stdenv.hostPlatform.darwinArch` and `stdenv.hostPlatform.linuxArch` return `arm64` if running on `aarch64` (cf, [`systems/default.nix`](https://github.com/NixOS/nixpkgs/blob/16ec3be15bef939c61639d3dae3fe67c651006e1/lib/systems/default.nix#L205-L245)), resulting in a broken url to the sdk source.

I verified that this fix is working on `x86_64-linux` and on `aarch64-darwin`. 

(Re-opening #11, now with the correct source branch)