### PR TITLE
Fix sdk install phase

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -86,7 +86,7 @@ in {
         installPhase = ''
           runHook preInstall
 
-          rm zephyr-sdk-$version/zephyr-sdk-${arch}-hosttools-standalone-*.sh
+          rm -f zephyr-sdk-$version/zephyr-sdk-${arch}-hosttools-standalone-*.sh
           rm -f env-vars
 
           mv zephyr-sdk-$version $out


### PR DESCRIPTION
`zephyr-sdk` doesn't contain `hosttools-standalone` scripts for non-linux platforms, resulting in a build failure on Darwin without the force flag. 