### PR TITLE
feat: remove flake input `zephyr`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,4 @@
-{ zephyr-src
-, pyproject-nix
+{ pyproject-nix
 , lib
 , newScope
 , openocd
@@ -32,7 +31,12 @@ in {
 
   # Zephyr/west Python environment.
   pythonEnv = callPackage ./python.nix {
-    inherit zephyr-src;
+    zephyr-src = fetchFromGitHub {
+      owner = "zephyrproject-rtos";
+      repo = "zephyr";
+      rev = "v3.7.0";
+      hash = "sha256-rmOHH0uRU27U2T4w4+FEMcAcuiZ7W7p4vOwtSwiAFNY=";
+    };
     inherit pyproject-nix;
   };
 

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731223003,
-        "narHash": "sha256-hFf8/IeZKPUubMC452Mm+JiAEnvcw/a4Cvn2bcpeJqs=",
+        "lastModified": 1733112511,
+        "narHash": "sha256-qQd6K8RYZpwEeawyqSnDkFCPZAIbz8c7BP9490EsgQM=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "359dd9cd562730bbd31ab164832aae4dacd9c302",
+        "rev": "60b55f8095cc1909d1c8f1806431f0f7f5f3fc32",
         "type": "github"
       },
       "original": {
@@ -60,25 +60,7 @@
       "inputs": {
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": "nixpkgs",
-        "pyproject-nix": "pyproject-nix",
-        "zephyr": "zephyr"
-      }
-    },
-    "zephyr": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1721992675,
-        "narHash": "sha256-rmOHH0uRU27U2T4w4+FEMcAcuiZ7W7p4vOwtSwiAFNY=",
-        "owner": "zephyrproject-rtos",
-        "repo": "zephyr",
-        "rev": "36940db938a8f4a1e919496793ed439850a221c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "zephyrproject-rtos",
-        "ref": "v3.7.0",
-        "repo": "zephyr",
-        "type": "github"
+        "pyproject-nix": "pyproject-nix"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,6 @@
     pyproject-nix.url = "github:nix-community/pyproject.nix";
     pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
 
-    zephyr.url = "github:zephyrproject-rtos/zephyr/v3.7.0";
-    zephyr.flake = false;
-
     nix-github-actions.url = "github:nix-community/nix-github-actions";
     nix-github-actions.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -18,7 +15,6 @@
     {
       self,
       nixpkgs,
-      zephyr,
       pyproject-nix,
       nix-github-actions,
     }:
@@ -64,7 +60,6 @@
             pkgs = nixpkgs.legacyPackages.${system};
 
             packages' = pkgs.callPackage ./. {
-              zephyr-src = zephyr;
               inherit pyproject-nix;
             };
 


### PR DESCRIPTION
This project only use `${zephyr}/scripts/requirements.txt`, we can use it as a fixed-output derivation like `openocd-zephyr`. If users use another version of Zephyr, they can simpliy override it.