### PR TITLE
Disable checks for canopen

### DIFF
--- a/python.nix
+++ b/python.nix
@@ -19,6 +19,11 @@ let
       # Nixpkgs has incorrect canonical naming
       python-can = super.python-can or self.can;
 
+      # Upstream bug. Network tests for canopen-2.3.0 may fail due to fragile timing assumptions
+      canopen = super.canopen.overridePythonAttrs (old: {
+        doCheck = false;
+      });
+
       # Nixpkgs puts imgtool in the top-level set as mcuboot-imgtool since 2024-10
       imgtool =
         if pkgs ? mcuboot-imgtool then pkgs.mcuboot-imgtool.override {


### PR DESCRIPTION
This disables checks for `canopen`, which fail on `aarch64-darwin`. Without having dug deeper, the FIXME comment in the error message suggests that they fail due to fragile timing assumptions in the tests rather than for substantive reasons.

```
error: builder for '/nix/store/7c35wjdq8qkbms76scqxcsv5ci16fis0-python3.12-canopen-2.3.0.drv' failed with exit code 1;
       last 25 log lines:
       > =================================== FAILURES ===================================
       > ________________________ TestNetwork.test_send_perodic _________________________
       >
       > self = <test_network.TestNetwork testMethod=test_send_perodic>
       >
       >     def test_send_perodic(self):
       >         bus = can.interface.Bus(bustype="virtual", channel=1)
       >         self.network.connect(bustype="virtual", channel=1)
       >
       >         task = self.network.send_periodic(0x123, [1, 2, 3], 0.01)
       >         time.sleep(0.1)
       >         # FIXME: This test is a little fragile, as the number of elements
       >         #        depends on the timing of the machine.
       >         print(f"Queue size: {bus.queue.qsize()}")
       > >       self.assertTrue(9 <= bus.queue.qsize() <= 13)
       > E       AssertionError: False is not true
       >
       > test/test_network.py:65: AssertionError
       > ----------------------------- Captured stdout call -----------------------------
       > Queue size: 18
       > ------------------------------ Captured log call -------------------------------
       > WARNING  canopen.objectdictionary.eds:eds.py:270 Complex data type has an unknown or unsupported data type (0x40)
       > =========================== short test summary info ============================
       > FAILED test/test_network.py::TestNetwork::test_send_perodic - AssertionError: False is not true
       > ======================== 1 failed, 119 passed in 13.31s ========================
       For full logs, run 'nix log /nix/store/7c35wjdq8qkbms76scqxcsv5ci16fis0-python3.12-canopen-2.3.0.drv'.
error: 1 dependencies of derivation '/nix/store/qmfyyggz2zad89g05hvqpj77s6dhcwsa-python3-3.12.8-env.drv' failed to build
```