### PR TITLE
Fix for issue "error: attribute 'gitlint' missing"

### DIFF
--- a/python.nix
+++ b/python.nix
@@ -10,6 +10,7 @@
 
 let
   packageOverrides = self: super: {
+    inherit gitlint;
     # HACK: Zephyr uses pypi to install non-Python deps
     clang-format = clang-tools;
 


### PR DESCRIPTION
made the package override for python3 inherit gitlint. 
seems like it has changed from gitlint-core to just gitlint. 

tested with the flake example in the README.md