### PR TITLE
Add `gnu_` prefix to darwin toolchain name

### DIFF
--- a/sdk.nix
+++ b/sdk.nix
@@ -6,10 +6,13 @@ let
 
   getToolchainPlatform =
     stdenv:
+    let
+      gnuPrefix = (if builtins.compareVersions version "1.0.0" >= 0 then "gnu_" else "");
+    in
     if stdenv.isLinux then
-      (if builtins.compareVersions version "1.0.0" >= 0 then "gnu_linux" else "linux")
+      "${gnuPrefix}linux"
     else if stdenv.isDarwin then
-      "macos"
+      "${gnuPrefix}macos"
     else
       throw "Unsupported platform";
 


### PR DESCRIPTION
Was also added in 1.0 SDKs